### PR TITLE
Remove migration and seeding from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,6 @@ services:
         composer install &&
         cp .env .env.backup &&
         php artisan config:clear &&
-        php artisan migrate --force &&
-        php artisan db:seed --force &&
         php artisan serve --host=0.0.0.0 --port=8000
       "
 


### PR DESCRIPTION
This pull request makes a minor update to the `docker-compose.yml` file by removing the database migration and seeding commands from the service startup script. This change means that migrations and seeding will no longer be automatically run when the service starts. 

- Removed automatic execution of `php artisan migrate --force` and `php artisan db:seed --force` from the service startup command in `docker-compose.yml`Removed database migration and seeding commands from the startup script.